### PR TITLE
fix: use 2-space indent on package*.json to avoid thrashing

### DIFF
--- a/config.js
+++ b/config.js
@@ -6,9 +6,18 @@ const config = {
 	useTabs: true,
 	singleQuote: true,
 	bracketSpacing: true,
-	trailingComma: "all",
-	proseWrap: "always",
-	endOfLine: "lf",
-};
+	trailingComma: 'all',
+	proseWrap: 'always',
+	endOfLine: 'lf',
+	overrides: [
+		{
+			files: ['package.json', 'package-lock.json'],
+			options: {
+				useTabs: false,
+				tabWidth: 2,
+			},
+		},
+	],
+}
 
-module.exports = config;
+module.exports = config

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,30 @@
 {
-	"name": "@express-rate-limit/prettier",
-	"version": "1.0.0",
-	"lockfileVersion": 3,
-	"requires": true,
-	"packages": {
-		"": {
-			"name": "@express-rate-limit/prettier",
-			"version": "1.0.0"
-		}
-	}
+  "name": "@express-rate-limit/prettier",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@express-rate-limit/prettier",
+      "version": "1.0.0",
+      "devDependencies": {
+        "prettier": "^3.0.2"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.2.tgz",
+      "integrity": "sha512-o2YR9qtniXvwEZlOKbveKfDQVyqxbEIWn48Z8m3ZJjBjcCmUy3xZGIv+7AkaeuaTr6yPXJjwv07ZWlsWbEy1rQ==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,12 +1,21 @@
 {
-	"name": "@express-rate-limit/prettier",
-	"version": "1.0.0",
-	"description": "The Prettier configuration for all express-rate-limit projects.",
-	"main": "config.js",
-	"repository": "https://github.com/express-rate-limit/prettier",
-	"files": [
-		"config.js",
-		"package.json",
-		"readme.md"
-	]
+  "name": "@express-rate-limit/prettier",
+  "version": "1.0.0",
+  "description": "The Prettier configuration for all express-rate-limit projects.",
+  "main": "config.js",
+  "repository": "https://github.com/express-rate-limit/prettier",
+  "files": [
+    "config.js",
+    "package.json",
+    "readme.md"
+  ],
+  "scripts": {
+    "lint": "prettier --ignore-path .gitignore --ignore-unknown --check .",
+    "format": "npm run lint -- --write",
+    "test": "npm run lint"
+  },
+  "prettier": "./config.js",
+  "devDependencies": {
+    "prettier": "^3.0.2"
+  }
 }

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
 # `@express-rate-limit/prettier`
 
-This package exports the [Prettier](https://prettier.io/) configuration used in all express-rate-limit
-projects.
+This package exports the [Prettier](https://prettier.io/) configuration used in
+all express-rate-limit projects.

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,4 @@
 # `@express-rate-limit/prettier`
 
-This package exports the Prettier configuration used in all express-rate-limit projects.
+This package exports the [Prettier](https://prettier.io/) configuration used in all express-rate-limit
+projects.


### PR DESCRIPTION
npm writes out `package.json` and `package-lock.json` with 2-space indent, and so things were thrashing back and forth when prettier changes them to use tabs. 

Honestly, we should probably just have it skip those files, but this is an improvement at least.

I also configured it to run itself on this repo because, why not :)